### PR TITLE
Use -p to support creating parent paths

### DIFF
--- a/pkg/plugins/vmvol/nfs_csi.go
+++ b/pkg/plugins/vmvol/nfs_csi.go
@@ -49,7 +49,7 @@ func commonHandler(pvs ...*vmvol.PodVol) []*vmvol.VolResult {
 							CreateContainer: []*api.Hook{
 								{
 									Path: "/usr/bin/mkdir",
-									Args: []string{podv.Destination},
+									Args: []string{"mkdir", "-p", podv.Destination},
 								},
 								{
 									Path: "/usr/bin/mount",


### PR DESCRIPTION
when the parent path does not exist, use -p to create it