### PR TITLE
fix helm chart nri socket path

### DIFF
--- a/charts/kcrowdaemon/templates/daemonset.yaml
+++ b/charts/kcrowdaemon/templates/daemonset.yaml
@@ -98,7 +98,7 @@ spec:
           name: kubeconfig
           readOnly: true
         {{- end }}
-        - mountPath: /run/nri/nri.sock
+        - mountPath: /var/run/nri/nri.sock
           name: socket
           readOnly: true
       volumes:

--- a/charts/kcrowdaemon/templates/daemonset.yaml
+++ b/charts/kcrowdaemon/templates/daemonset.yaml
@@ -111,4 +111,4 @@ spec:
       - name: socket
         hostPath:
           path: {{ .Values.controller.nriSock }}
-          type: File
+          type: Socket

--- a/charts/kcrowdaemon/values.yaml
+++ b/charts/kcrowdaemon/values.yaml
@@ -38,7 +38,7 @@ controller:
   hostnetwork: true
 
   ## @param controller.nrisock the nri socket path
-  nriSock: "/run/nri/nri.sock"
+  nriSock: "/var/run/nri/nri.sock"
 
   ## @param controller.kubeconfig the kubeconfig file path, 
   ## Notice, When this is configured, the serviceAccount will be ignored.


### PR DESCRIPTION
change helm chart nri socket path  to /var/run/nri/nri.sock
change  nri socket hostpathType to Socket in daemonset yaml

issue: https://github.com/kcrow-io/kcrow/issues/21